### PR TITLE
Force utf-8 encoding when reading ChangeLog.

### DIFF
--- a/pyatmlab/meta.py
+++ b/pyatmlab/meta.py
@@ -14,7 +14,7 @@ def get_version(path_to_changelog):
     :returns: String with version number major.minor.micro
     """
 
-    with open(path_to_changelog, 'r') as f:
+    with open(path_to_changelog, 'r', encoding='utf-8') as f:
         # should be on third line
         f.readline()
         f.readline()


### PR DESCRIPTION
get_version() fails with a UnicodeDecodeError if the user's
locale is not set to UTF-8, e.g.: LC_ALL=C

```
$ LC_ALL=C pip install -e .                                           
Obtaining file:///scratch/uni/u237/users/olemke/Hacking/pyatmlab
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/scratch/uni/u237/users/olemke/Hacking/pyatmlab/setup.py", line 19, in <module>
        version = get_version(),
      File "/scratch/uni/u237/users/olemke/Hacking/pyatmlab/setup.py", line 15, in get_version
        return get_v(os.path.join(os.path.dirname(__file__), "ChangeLog"))
      File "/scratch/uni/u237/users/olemke/Hacking/pyatmlab/pyatmlab/meta.py", line 19, in get_version
        f.readline()
      File "/scratch/uni/u237/sw/miniconda/lib/python3.4/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 6701: ordinal not in range(128)
```
